### PR TITLE
fix bug, odriver is not working for cabot-s1

### DIFF
--- a/docker-compose-base.yaml
+++ b/docker-compose-base.yaml
@@ -9,6 +9,8 @@ services:
       - CABOT_MODEL
       - CABOT_SIDE
       - CABOT_TOUCH_PARAMS
+      - CABOT_ODRIVER_SERIAL_0
+      - CABOT_ODRIVER_SERIAL_1
     volumes:
 # device, bluetooth
       - /dev:/dev


### PR DESCRIPTION
fix bug, odriver is not  working for cabot-s1 model

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>