### PR TITLE
fix bug, laserscan is not working on real robot

### DIFF
--- a/docker/driver/Dockerfile
+++ b/docker/driver/Dockerfile
@@ -37,7 +37,8 @@ RUN apt update && apt install -y \
     python3-dbus \
 	ros-${ROS_DISTRO}-diagnostic-updater \
     ros-${ROS_DISTRO}-xacro \
-    ros-${ROS_DISTRO}-realsense2-description
+    ros-${ROS_DISTRO}-realsense2-description \
+    ros-${ROS_DISTRO}-pointcloud-to-laserscan
 
 RUN pip3 install --no-cache-dir \
     odrive==0.6.5 \


### PR DESCRIPTION
Because driver docker image does not have ros-humble-pointcloud-to-laserscan package, I had following error for real robot and /scan topic is not working.
This pull request fix the error.

```
1707387930.4190190 [ERROR] [launch_ros.actions.load_composable_nodes]: Failed to load node 'pointcloud_to_laserscan_node' of type 'pointcloud_to_laserscan::PointCloudToLaserScanNode' in container '/laser_container': Could not find requested resource in ament index
```

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>