### PR TITLE
fix bug of people detection on ACE model, static transform from robot model is not working on remote hosts

### DIFF
--- a/docker-compose-base.yaml
+++ b/docker-compose-base.yaml
@@ -11,6 +11,10 @@ services:
       - CABOT_TOUCH_PARAMS
       - CABOT_ODRIVER_SERIAL_0
       - CABOT_ODRIVER_SERIAL_1
+      - RMW_IMPLEMENTATION
+      - CYCLONEDDS_URI
+      - CYCLONEDDS_NETWORK_INTERFACE_NAME
+      - CYCLONEDDS_NETWORK_INTERFACE_AUTODETERMINE # set automatically by launch.sh
     volumes:
 # device, bluetooth
       - /dev:/dev


### PR DESCRIPTION
static transform from robot model is not working for remote hosts, and people detection failed on ACE models by following errors
```
[component_container-1] [0m[INFO] [1707808631.403036898] [rs3.detect_darknet_people_cpp]: tf2 error: "rs3_link" passed to lookupTransform argument source_frame does not exist. [0m
[component_container-1] [0m[INFO] [1707808631.536258628] [rs2.detect_darknet_people_cpp]: tf2 error: "rs2_link" passed to lookupTransform argument source_frame does not exist. [0m
[component_container-1] [0m[INFO] [1707808631.668497603] [rs1.detect_darknet_people_cpp]: tf2 error: "rs1_link" passed to lookupTransform argument source_frame does not exist. [0m
```
This pull request changed DDS settings to fix this error.

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>