### PR TITLE
fix docker build error when DOCKER_BUILDKIT is disabled

### DIFF
--- a/docker/driver/Dockerfile
+++ b/docker/driver/Dockerfile
@@ -75,5 +75,3 @@ USER $USERNAME
 ENV HOME /home/$USERNAME
 
 WORKDIR $HOME/driver_ws
-
-RUN mkdir -p src && git clone http://github.com/wg-perception/people.git -b ros2 src/people


### PR DESCRIPTION
When I set `DOCKER_BUILDKIT=0` to build docker image on Jetson, I had following build error.
```
 ---> Using cache
Step 20/22 : WORKDIR $HOME/driver_ws
 ---> Using cache
 ---> 160fa13e2877
Step 21/22 : RUN mkdir -p src && git clone http://github.com/wg-perception/people.git -b ros2 src/people
[+] Building 0.0s (0/0)                                                                                                                                                                                                                                                           
[+] Building 0.0s (0/0)                                                                                                                                                                                                                                                           
[+] Building 0.0s (0/0)                                                                                                                                                                                                                                                           
The command '/bin/sh -c mkdir -p src && git clone http://github.com/wg-perception/people.git -b ros2 src/people' returned a non-zero code: 1
```

This error happens because [this liine](https://github.com/CMU-cabot/cabot-drivers/blob/7900c06aa1d4cc8dbef6a84c35fb0bf8595ca403/docker/driver/Dockerfile#L79) tries to create the same folder which is mounted by [this line](https://github.com/CMU-cabot/cabot-drivers/blob/7900c06aa1d4cc8dbef6a84c35fb0bf8595ca403/docker-compose-base.yaml#L32).

This pull request fixes the build error.

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>