### PR TITLE
fix odriver_adapter to disable velocity error feedback when velocity command is zero (stop command)

### DIFF
--- a/motor_controller/motor_adapter/src/odriver_adapter.cpp
+++ b/motor_controller/motor_adapter/src/odriver_adapter.cpp
@@ -152,11 +152,12 @@ void ODriverNode::cmdVelLoop(int publishRate)
     }
 
     // linear and velocity error feedback
-    // apply feedback after receiving at least one motorStatus message, when loop control is on, and
-    // last odometry is new (within 200ms) to prevent integrator error accumulation
-    if (lastOdomTime_ > rclcpp::Time(0, 0, get_clock()->get_clock_type())
-        && get_clock()->now() - lastOdomTime_ < rclcpp::Duration(200ms)
-        && target.loop_ctrl ) {
+    // apply feedback only when the following conditions are met to prevent integrator error accumulation
+    if (lastOdomTime_ > rclcpp::Time(0, 0, get_clock()->get_clock_type()) // after receiving at least one motorStatus message
+        && get_clock()->now() - lastOdomTime_ < rclcpp::Duration(200ms) // last odometry is almost up-to-date (within 200ms)
+        && target.loop_ctrl  // loop control is on
+        && !(targetSpdLinear_ == 0.0 and targetSpdTurn_ == 0.0)  // command velocity is non-zero
+        ) {
       rclcpp::Time now = get_clock()->now();
       double dt = 1.0 / publishRate;
       double fixedMeasuredSpdTurn = measuredSpdTurn_;


### PR DESCRIPTION
Fixed a strange behavior that the robot very slightly rotates even when the touch sensor is released under the condition that the angular velocity error feedback is active.
To fix the issue, odriver_adapter was fixed to disable velocity error feedback and stop integrator error accumulation when velocity command is completely zero. (cmd_vel.linear==0 and cmd_vel.angular==0)