### PR TITLE
add ready flag to avoid publishing invalid motor status

### DIFF
--- a/motor_controller/odriver_can_adapter/include/odrive_manager.hpp
+++ b/motor_controller/odriver_can_adapter/include/odrive_manager.hpp
@@ -39,6 +39,7 @@ public:
   double getCurrentSetpoint() { return current_setpoint_; };
   double getCurrentMeasured() { return current_measured_; };
   double getSign() { return sign_; };
+  bool isReady() { return ready_; };
 private:
   rclcpp::Node *node_;
 
@@ -54,6 +55,7 @@ private:
   double dist_c_;
   double current_setpoint_;
   double current_measured_;
+  bool ready_;
 
   double sign_;
 

--- a/motor_controller/odriver_can_adapter/src/odrive_manager.cpp
+++ b/motor_controller/odriver_can_adapter/src/odrive_manager.cpp
@@ -36,6 +36,7 @@ ODriveManager::ODriveManager(rclcpp::Node *node, const std::string &axis_name,
     is_ready_axis_state_service_(true),
     axis_name_(axis_name),
     sign_(sign),
+    ready_(false),
     wheel_diameter_m_(wheel_diameter_m)
 {
   using std::placeholders::_1;
@@ -72,6 +73,7 @@ void ODriveManager::controllerStatusCallback(const odrive_can::msg::ControllerSt
   current_setpoint_ = msg->iq_setpoint;
   current_measured_ = msg->iq_measured;
   axis_state_ = msg->axis_state;
+  ready_ = true;
 }
 
 void ODriveManager::callAxisStateService(unsigned int axis_state)

--- a/motor_controller/odriver_can_adapter/src/odriver_can_adapter_node.cpp
+++ b/motor_controller/odriver_can_adapter/src/odriver_can_adapter_node.cpp
@@ -142,6 +142,11 @@ private:
     odrive_left_->checkTimeoutServiceResponse(service_timeout_ms_);
     odrive_right_->checkTimeoutServiceResponse(service_timeout_ms_);
 
+    if (!odrive_left_->isReady() || !odrive_right_->isReady()) {
+      // do not publish MotorStatus if one of odrives is not ready
+      return;
+    }
+
     double sign_left = odrive_left_->getSign();
     double sign_right = odrive_right_->getSign();
     double dist_left_c = odrive_left_->getDistC();


### PR DESCRIPTION
@yushi-minemura, @muratams 

The current odriver_can_adapter can publish non-initialized values as motor status.
It may cause NaN values in odometry topics.
Please test with this code.
