### PR TITLE
delete unnecessary pressure topic remapping of cabot_can_node in cabot3.launch.py

### DIFF
--- a/cabot_base/launch/cabot3.launch.py
+++ b/cabot_base/launch/cabot3.launch.py
@@ -472,7 +472,6 @@ def generate_launch_description():
                 remappings=[
                     ('/cabot/imu', '/cabot/imu/data'),
                     ('/cabot/touch_speed', '/cabot/touch_speed_raw'),
-                    ('/cabot/bme/pressure', '/cabot/pressure')
                 ],
                 condition=IfCondition(AndSubstitution(use_can, NotSubstitution(use_sim_time)))
             ),


### PR DESCRIPTION
This pull request fixes a bug that `/cabot/pressure` topic is published twice per one data reception.

[cabot_can_node publishes pressure data to both `pressure` topic and `bme/pressure` topic.](https://github.com/CMU-cabot/cabot-drivers/blob/e5b2a3b1c53d226c1037561f4753a9ae96133b06/cabot_can/src/cabot_can_node.cpp#L454-L455)
Because `/cabot/bme/pressure` topic is remapped to `/cabot/pressure` in cabot3.launch.py, `/cabot/pressure` topic is published twice per one [publishBmeData](https://github.com/CMU-cabot/cabot-drivers/blob/e5b2a3b1c53d226c1037561f4753a9ae96133b06/cabot_can/src/cabot_can_node.cpp#L437C8-L437C22) call.