### PR TITLE
clean up ros_entrypoint.sh for supporting the command with double quotes in docker compose files

### DIFF
--- a/docker/driver/ros_entrypoint.sh
+++ b/docker/driver/ros_entrypoint.sh
@@ -24,6 +24,4 @@ fi
 # Source ROS setup script
 source "/opt/custom_ws/install/setup.bash"
 
-WORKDIR=$(pwd)
-
-exec gosu developer bash -c "cd $WORKDIR && exec $*"
+exec gosu developer "$@"


### PR DESCRIPTION
This pull request fixed issue that command in docker compose file does not support special characters.

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>