### PR TITLE
fix remapping of odrive_status topic published by odrive_can_node

### DIFF
--- a/cabot_base/launch/cabot3.launch.py
+++ b/cabot_base/launch/cabot3.launch.py
@@ -578,6 +578,7 @@ def generate_launch_description():
                 remappings=[
                     ('/cabot/control_message', '/cabot/control_message_left'),
                     ('/cabot/controller_status', '/cabot/controller_status_left'),
+                    ('/cabot/odrive_status', '/cabot/odrive_status_left'),
                     ('/cabot/request_axis_state', '/cabot/request_axis_state_left')
                 ],
                 condition=IfCondition(AndSubstitution(use_can, NotSubstitution(use_sim_time)))
@@ -599,6 +600,7 @@ def generate_launch_description():
                 remappings=[
                     ('/cabot/control_message', '/cabot/control_message_right'),
                     ('/cabot/controller_status', '/cabot/controller_status_right'),
+                    ('/cabot/odrive_status', '/cabot/odrive_status_right'),
                     ('/cabot/request_axis_state', '/cabot/request_axis_state_right'),
                 ],
                 condition=IfCondition(AndSubstitution(use_can, NotSubstitution(use_sim_time)))


### PR DESCRIPTION
This commit updates remapping of odrive_status topic published by odrive_can_node.
Currently, odrive_status from both left and right odrive nodes are published to `/cabot/odrive_status` topic.
It is better to publish odrive status from the left odrive_can node to `/cabot/odrive_status_left` and from the right node to `/cabot/odrive_status_right`.