### PR TITLE
fix cabot_can.launch.py to run esp32_wifi_scan_converter

### DIFF
--- a/cabot_can/launch/cabot_can.launch.py
+++ b/cabot_can/launch/cabot_can.launch.py
@@ -94,4 +94,20 @@ def generate_launch_description():
                 ('/cabot/touch_speed', '/cabot/touch_speed_raw'),
             ],
         ),
+        # wifi scan converter for cabot_can
+        Node(
+            package='wireless_scanner_ros',
+            executable='esp32_wifi_scan_converter.py',
+            namespace='/cabot',
+            name='esp32_wifi_scan_converter',
+            output=output,
+            parameters=[
+                {
+                    'use_sim_time': use_sim_time,
+                }
+            ],
+            remappings=[
+                ('/esp32/wifi_scan_str', '/cabot/wifi'),
+            ],
+        )
     ])


### PR DESCRIPTION
This Pull Request fixes a bug that /esp32/wifi topic is not published because esp32_wifi_scan_converter does not work on cabot3-k4. This bug was caused by Pull Request https://github.com/CMU-cabot/cabot-drivers/pull/69.