### PR TITLE
fix odriver can adapter

### DIFF
--- a/motor_controller/odriver_can_adapter/include/odrive_manager.hpp
+++ b/motor_controller/odriver_can_adapter/include/odrive_manager.hpp
@@ -38,7 +38,7 @@ public:
   void checkTimeoutServiceResponse(double timeout);
   double getSpdC() {return spd_c_;}
   double getDistC() {return dist_c_;}
-  double getDistCFixed();
+  double getDistCFixed() {return dist_c_fixed_;}
   double getCurrentSetpoint() {return current_setpoint_;}
   double getCurrentMeasured() {return current_measured_;}
   double getSign() {return sign_;}
@@ -63,6 +63,7 @@ private:
   double current_measured_;
   bool ready_;
 
+  rclcpp::Time status_time_;
   rclcpp::Time last_status_time_;
 
   double sign_;

--- a/motor_controller/odriver_can_adapter/include/odrive_manager.hpp
+++ b/motor_controller/odriver_can_adapter/include/odrive_manager.hpp
@@ -38,10 +38,12 @@ public:
   void checkTimeoutServiceResponse(double timeout);
   double getSpdC() {return spd_c_;}
   double getDistC() {return dist_c_;}
+  double getDistCFixed();
   double getCurrentSetpoint() {return current_setpoint_;}
   double getCurrentMeasured() {return current_measured_;}
   double getSign() {return sign_;}
   bool isReady() {return ready_;}
+  rclcpp::Time getLastStatusTime() {return last_status_time_;}
 
 private:
   rclcpp::Node * node_;
@@ -55,9 +57,13 @@ private:
 
   double spd_c_;
   double dist_c_;
+  double dist_c_fixed_;
+  double last_dist_c_;
   double current_setpoint_;
   double current_measured_;
   bool ready_;
+
+  rclcpp::Time last_status_time_;
 
   double sign_;
 

--- a/motor_controller/odriver_can_adapter/src/odriver_can_adapter_node.cpp
+++ b/motor_controller/odriver_can_adapter/src/odriver_can_adapter_node.cpp
@@ -159,8 +159,8 @@ private:
 
     double sign_left = odrive_left_->getSign();
     double sign_right = odrive_right_->getSign();
-    double dist_left_c = odrive_left_->getDistC();
-    double dist_right_c = odrive_right_->getDistC();
+    double dist_left_c = odrive_left_->getDistCFixed();
+    double dist_right_c = odrive_right_->getDistCFixed();
     double spd_left_c = odrive_left_->getSpdC();
     double spd_right_c = odrive_right_->getSpdC();
     double current_setpoint_left = odrive_left_->getCurrentSetpoint();
@@ -191,7 +191,11 @@ private:
     status.current_measured_right = sign_right * current_measured_right;
 
     motor_status_pub_->publish(status);
-    last_motor_status_time_ = this->get_clock()->now();
+    rclcpp::Time temp = odrive_left_->getLastStatusTime();
+    if (odrive_right_->getLastStatusTime() < temp) {
+      temp = odrive_right_->getLastStatusTime();
+    }
+    last_motor_status_time_ = temp;
   }
 
   void checkMotorStatus(diagnostic_updater::DiagnosticStatusWrapper & stat)


### PR DESCRIPTION
- ODrive raw odometry can be reset when it encounters errors, and this can cause a significant jump in odometry
- `getDistCFixed` tries to adjust the odometry count by checking the time difference between the incoming and the last observation