### PR TITLE
Fix odrive can adapter

### DIFF
--- a/cabot_base/launch/cabot3.launch.py
+++ b/cabot_base/launch/cabot3.launch.py
@@ -545,6 +545,8 @@ def generate_launch_description():
                     ('/motor_target', '/cabot/motorTarget'),
                     ('/request_axis_state_left', '/cabot/request_axis_state_left'),
                     ('/request_axis_state_right', '/cabot/request_axis_state_right'),
+                    ('/odrive_status_left', '/cabot/odrive_status_left'),
+                    ('/odrive_status_right', '/cabot/odrive_status_right'),
                 ],
                 condition=IfCondition(AndSubstitution(use_can_odrive, NotSubstitution(use_sim_time)))
             ),

--- a/cabot_base/launch/cabot3.launch.py
+++ b/cabot_base/launch/cabot3.launch.py
@@ -547,6 +547,7 @@ def generate_launch_description():
                     ('/request_axis_state_right', '/cabot/request_axis_state_right'),
                     ('/odrive_status_left', '/cabot/odrive_status_left'),
                     ('/odrive_status_right', '/cabot/odrive_status_right'),
+                    ('/set_odrive_power', '/set_24v_power_odrive'),
                 ],
                 condition=IfCondition(AndSubstitution(use_can_odrive, NotSubstitution(use_sim_time)))
             ),

--- a/motor_controller/odriver_can_adapter/CMakeLists.txt
+++ b/motor_controller/odriver_can_adapter/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(rclcpp REQUIRED)
 find_package(diagnostic_updater REQUIRED)
 find_package(odriver_msgs REQUIRED)
 find_package(odrive_can REQUIRED)
+find_package(std_srvs REQUIRED)
 
 add_executable(odriver_can_adapter_node
   src/odriver_can_adapter_node.cpp
@@ -25,6 +26,7 @@ ament_target_dependencies(
   "diagnostic_updater"
   "odriver_msgs"
   "odrive_can"
+  "std_srvs"
 )
 
 include_directories(include)

--- a/motor_controller/odriver_can_adapter/include/odrive_manager.hpp
+++ b/motor_controller/odriver_can_adapter/include/odrive_manager.hpp
@@ -24,6 +24,11 @@
 
 #include <string>
 
+#include <odrive_can/msg/control_message.hpp>
+#include <odrive_can/msg/controller_status.hpp>
+#include <odrive_can/msg/o_drive_status.hpp>
+#include <odrive_can/srv/axis_state.hpp>
+
 class ODriveManager
 {
 public:
@@ -31,7 +36,8 @@ public:
   ~ODriveManager();
 
   void controllerStatusCallback(const odrive_can::msg::ControllerStatus::SharedPtr msg);
-  void callAxisStateService(unsigned int axis_state);
+  void odriveStatusCallback(const odrive_can::msg::ODriveStatus::SharedPtr msg);
+  bool callAxisStateService(unsigned int axis_state);
   void publishControlMessage(const odrive_can::msg::ControlMessage & msg);
   void publishControlMessage(int control_mode, int input_mode, double spd_m_per_sec);
   unsigned int getAxisState() {return axis_state_;}
@@ -44,6 +50,8 @@ public:
   double getSign() {return sign_;}
   bool isReady() {return ready_;}
   rclcpp::Time getLastStatusTime() {return last_status_time_;}
+  int getActiveErrors() {return active_errors_;}
+  int getDisarmReason() {return disarm_reason_;}
 
 private:
   rclcpp::Node * node_;
@@ -61,6 +69,8 @@ private:
   double last_dist_c_;
   double current_setpoint_;
   double current_measured_;
+  uint32_t active_errors_;
+  uint32_t disarm_reason_;
   bool ready_;
 
   rclcpp::Time status_time_;
@@ -73,4 +83,5 @@ private:
 
   rclcpp::Publisher<odrive_can::msg::ControlMessage>::SharedPtr control_message_pub_;
   rclcpp::Subscription<odrive_can::msg::ControllerStatus>::SharedPtr controller_status_sub_;
+  rclcpp::Subscription<odrive_can::msg::ODriveStatus>::SharedPtr odrive_status_sub_;
 };

--- a/motor_controller/odriver_can_adapter/launch/test.launch.py
+++ b/motor_controller/odriver_can_adapter/launch/test.launch.py
@@ -70,6 +70,8 @@ def generate_launch_description():
                 ('/motor_target', '/cabot/motor_target'),
                 ('/request_axis_state_left', '/cabot/request_axis_state_left'),
                 ('/request_axis_state_right', '/cabot/request_axis_state_right'),
+                ('/odrive_status_left', '/cabot/odrive_status_left'),
+                ('/odrive_status_right', '/cabot/odrive_status_right'),
             ],
         ),
         Node(

--- a/motor_controller/odriver_can_adapter/launch/test.launch.py
+++ b/motor_controller/odriver_can_adapter/launch/test.launch.py
@@ -72,6 +72,7 @@ def generate_launch_description():
                 ('/request_axis_state_right', '/cabot/request_axis_state_right'),
                 ('/odrive_status_left', '/cabot/odrive_status_left'),
                 ('/odrive_status_right', '/cabot/odrive_status_right'),
+                ('/set_odrive_power', '/set_24v_power_odrive'),
             ],
         ),
         Node(

--- a/motor_controller/odriver_can_adapter/package.xml
+++ b/motor_controller/odriver_can_adapter/package.xml
@@ -29,6 +29,8 @@
   <depend>rclcpp</depend>
   <depend>odriver_msgs</depend>
   <depend>odrive_can</depend>
+  <depend>std_srvs</depend>
+  <depend>diagnostic_updater</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/motor_controller/odriver_can_adapter/src/odrive_manager.cpp
+++ b/motor_controller/odriver_can_adapter/src/odrive_manager.cpp
@@ -24,10 +24,6 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <odrive_can/msg/control_message.hpp>
-#include <odrive_can/msg/controller_status.hpp>
-#include <odrive_can/srv/axis_state.hpp>
-
 #include "odrive_manager.hpp"
 
 using namespace std::chrono_literals;
@@ -41,6 +37,8 @@ ODriveManager::ODriveManager(
   dist_c_fixed_(0),
   last_dist_c_(std::numeric_limits<double>::quiet_NaN()),
   ready_(false),
+  active_errors_(0),
+  disarm_reason_(0),
   last_status_time_(node->get_clock()->now()),
   sign_(sign),
   wheel_diameter_m_(wheel_diameter_m)
@@ -60,6 +58,13 @@ ODriveManager::ODriveManager(
     controller_status_qos,
     std::bind(
       &ODriveManager::controllerStatusCallback,
+      this,
+      _1));
+  odrive_status_sub_ = node->create_subscription<odrive_can::msg::ODriveStatus>(
+    (std::string("/odrive_status_") + axis_name).c_str(),
+    controller_status_qos,
+    std::bind(
+      &ODriveManager::odriveStatusCallback,
       this,
       _1));
 
@@ -100,7 +105,13 @@ void ODriveManager::controllerStatusCallback(const odrive_can::msg::ControllerSt
   }
 }
 
-void ODriveManager::callAxisStateService(unsigned int axis_state)
+void ODriveManager::odriveStatusCallback(const odrive_can::msg::ODriveStatus::SharedPtr msg)
+{
+  active_errors_ = msg->active_errors;
+  disarm_reason_ = msg->disarm_reason;
+}
+
+bool ODriveManager::callAxisStateService(unsigned int axis_state)
 {
   using AxisState = odrive_can::srv::AxisState;
   using AxisStateClient = rclcpp::Client<AxisState>;
@@ -110,19 +121,22 @@ void ODriveManager::callAxisStateService(unsigned int axis_state)
   request->axis_requested_state = axis_state;
 
   if (is_ready_axis_state_service_) {
-    RCLCPP_INFO(
+    RCLCPP_INFO_THROTTLE(
       node_->get_logger(),
+      *node_->get_clock(),
+      2000,
       "call axis_state_%s service from %d mode to %d mode",
       axis_name_.c_str(),
       axis_state_,
       axis_state);
-    while (!client_->wait_for_service(std::chrono::seconds(1)) &&
-      rclcpp::ok())
-    {
-      RCLCPP_INFO(
+    if (rclcpp::ok() && !client_->wait_for_service(std::chrono::milliseconds(100))) {
+      RCLCPP_INFO_THROTTLE(
         node_->get_logger(),
+        *node_->get_clock(),
+        2000,
         "request_axis_state_%s service not available, waiting again...",
         axis_name_.c_str());
+      return false;
     }
 
     is_ready_axis_state_service_ = false;
@@ -134,7 +148,9 @@ void ODriveManager::callAxisStateService(unsigned int axis_state)
         (void) future;
         is_ready_axis_state_service_ = true;
       });
+    return true;
   }
+  return false;
 }
 
 void ODriveManager::publishControlMessage(const odrive_can::msg::ControlMessage & msg)

--- a/motor_controller/odriver_can_adapter/src/odriver_can_adapter_node.cpp
+++ b/motor_controller/odriver_can_adapter/src/odriver_can_adapter_node.cpp
@@ -221,6 +221,7 @@ private:
       request->data = need_power_on_;
       if (need_power_on_) {
         need_power_on_ = false;
+        last_motor_armed_time_ = this->get_clock()->now();
       }
       SetBoolClient::SharedFutureWithRequestAndRequestId set_odrive_power_future =
         set_odrive_power_client_->async_send_request(

--- a/motor_controller/odriver_can_adapter/src/odriver_can_adapter_node.cpp
+++ b/motor_controller/odriver_can_adapter/src/odriver_can_adapter_node.cpp
@@ -244,12 +244,13 @@ private:
     if ((odrive_left_->getDisarmReason() != 0) || (odrive_right_->getDisarmReason() != 0)) {
       stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "ODrive is disarmed.");
       return;
+    } else {
+      last_motor_armed_time_ = this->get_clock()->now();
     }
     if (diff.seconds() > motor_status_timeout_sec_) {
       stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Motor status is ERROR.");
       return;
     }
-    last_motor_armed_time_ = this->get_clock()->now();
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Motor status is OK.");
   }
 


### PR DESCRIPTION
- Output error diagnostic if odrive is disarmed
- If disarmament is continued for more than 5 seconds, turn off and on the odrive
