### PR TITLE
v2.4.2 development into main

### DIFF
--- a/cabot_base/config/cabot3-common.yaml
+++ b/cabot_base/config/cabot3-common.yaml
@@ -9,7 +9,7 @@ pointcloud_to_laserscan_node:
     angle_max: 1.57  # M_PI/2
     angle_increment: 0.00436  # M_PI/360/2
     scan_time: 0.1
-    range_min: 0.2
+    range_min: 0.01
     range_max: 50.0
     use_inf: True
     inf_epsilon: 1.0

--- a/cabot_base/config/cabot3-k4.yaml
+++ b/cabot_base/config/cabot3-k4.yaml
@@ -24,7 +24,7 @@ cabot:
     ros__parameters:
       bias: 0.14 # same with cabot3-i1
       gain_omega: 0.0
-      max_acc: 0.6
+      max_acc: 0.3
 
   cabot_can:
     ros__parameters:

--- a/cabot_base/launch/cabot3.launch.py
+++ b/cabot_base/launch/cabot3.launch.py
@@ -545,6 +545,9 @@ def generate_launch_description():
                     ('/motor_target', '/cabot/motorTarget'),
                     ('/request_axis_state_left', '/cabot/request_axis_state_left'),
                     ('/request_axis_state_right', '/cabot/request_axis_state_right'),
+                    ('/odrive_status_left', '/cabot/odrive_status_left'),
+                    ('/odrive_status_right', '/cabot/odrive_status_right'),
+                    ('/set_odrive_power', '/set_24v_power_odrive'),
                 ],
                 condition=IfCondition(AndSubstitution(use_can_odrive, NotSubstitution(use_sim_time)))
             ),

--- a/cabot_can/README.md
+++ b/cabot_can/README.md
@@ -19,8 +19,10 @@
     - Can be set by setting parameters in calibration_params of params.yaml
 - **touch_mode** (string) - default=`touch_mode_`
     - Selecting Sensors for /touch (ToF Sensors, Capacitive Sensors, or Both)
-- **tof_touch_threshold** (int) - default=`25`
-    - Determine the maximum distance threshold for the ToF sensor
+- **tof_touch_threshold_low** (int) - default=`25` (CABOT_TOF_TOUCH_THRESHOLD_LOW)
+    - Determine the distance threshold to enable tof detection
+- **tof_touch_threshold_high** (int) - default=`35`(CABOT_TOF_TOUCH_THRESHOLD_HIGH)
+    - Determine the distance threshold to disable tof detection (after enabling)
 ### Publishers
 - **/calibration** (int[22]): only publishes values when `/run_imu_calibration` is true
 - **/imu** (sensor_msgs/msg/Imu): IMU data - 100Hz

--- a/cabot_can/launch/cabot_can.launch.py
+++ b/cabot_can/launch/cabot_can.launch.py
@@ -40,6 +40,8 @@ def generate_launch_description():
     # touch_enabled = LaunchConfiguration('touch_enabled')  # TODO not implemented
     imu_accel_bias = LaunchConfiguration('imu_accel_bias')
     imu_gyro_bias = LaunchConfiguration('imu_gyro_bias')
+    tof_touch_threshold_low = LaunchConfiguration('tof_touch_threshold_low')
+    tof_touch_threshold_high = LaunchConfiguration('tof_touch_threshold_high')
 
     return LaunchDescription([
         # save all log file in the directory where the launch.log file is saved
@@ -74,6 +76,16 @@ def generate_launch_description():
             default_value=EnvironmentVariable('CABOT_IMU_GYRO_BIAS', default_value='[0.0, 0.0, 0.0]'),
             description='An array of three values for adjusting imu angular velocity'
         ),
+        DeclareLaunchArgument(
+            'tof_touch_threshold_low',
+            default_value=EnvironmentVariable('CABOT_TOF_TOUCH_THRESHOLD_LOW', default_value='25'),
+            description='The distance threshold to enable tof detection'
+        ),
+        DeclareLaunchArgument(
+            'tof_touch_threshold_high',
+            default_value=EnvironmentVariable('CABOT_TOF_TOUCH_THRESHOLD_HIGH', default_value='35'),
+            description='The distance threshold to disable tof detection (after enabling)'
+        ),
         Node(
             package='cabot_can',
             executable='cabot_can_node',
@@ -86,7 +98,9 @@ def generate_launch_description():
                     'use_sim_time': use_sim_time,
                     'touch_params': touch_params,
                     'imu_accel_bias': imu_accel_bias,
-                    'imu_gyro_bias': imu_gyro_bias
+                    'imu_gyro_bias': imu_gyro_bias,
+                    'tof_touch_threshold_low': tof_touch_threshold_low,
+                    'tof_touch_threshold_high': tof_touch_threshold_high,
                 }
             ],
             remappings=[

--- a/cabot_can/src/cabot_can_node.cpp
+++ b/cabot_can/src/cabot_can_node.cpp
@@ -130,12 +130,15 @@ class CabotCanNode : public rclcpp::Node
 public:
   CabotCanNode()
   : touch_mode_("cap"),
-    tof_touch_threshold_(25),
+    tof_touch_threshold_low_(25),
+    tof_touch_threshold_high_(35),
+    tof_touch_(false),
     Node("cabot_can_node"),
     diagnostic_updater_(this)
   {
     declare_parameter("touch_mode", touch_mode_);
-    declare_parameter("tof_touch_threshold", tof_touch_threshold_);
+    tof_touch_threshold_low_ = declare_parameter("tof_touch_threshold_low", tof_touch_threshold_low_);
+    tof_touch_threshold_high_ = declare_parameter("tof_touch_threshold_high", tof_touch_threshold_high_);
     declare_parameter("publish_rate", 200);
     declare_parameter("can_interface", "can0");
     declare_parameter("imu_frame_id", "imu_frame");
@@ -289,8 +292,11 @@ public:
       if (param.get_name() == "touch_mode") {
         touch_mode_ = param.as_string();
       }
-      if (param.get_name() == "tof_touch_threshold") {
-        tof_touch_threshold_ = param.as_int();
+      if (param.get_name() == "tof_touch_threshold_low") {
+        tof_touch_threshold_low_ = this->get_parameter("tof_touch_threshold_low").as_int();
+      }
+      if (param.get_name() == "tof_touch_threshold_high") {
+        tof_touch_threshold_high_ = this->get_parameter("tof_touch_threshold_high").as_int();
       }
       if (param.get_name() == "publish_imu_raw") {
         publish_imu_raw_ = param.as_bool();
@@ -706,41 +712,45 @@ private:
       capacitive_touch_msg.data = capacitive_touch;
       capacitive_touch_pub_->publish(capacitive_touch_msg);
       diag_tof_touch_raw_->tick(this->now());
-      int16_t capacitive_touch_raw = frame.data[2];
+      int8_t capacitive_touch_raw = frame.data[2];
       std_msgs::msg::Int16 capacitive_touch_raw_msg;
       capacitive_touch_raw_msg.data = capacitive_touch_raw;
       capacitive_touch_raw_pub_->publish(capacitive_touch_raw_msg);
       diag_cap_touch_raw_->tick(this->now());
       uint16_t tof_touch_raw = (((uint16_t)frame.data[1]) << 8) | ((uint16_t)frame.data[0]);
-      std_msgs::msg::UInt16 tof_raw_msg;
-      tof_raw_msg.data = tof_touch_raw;
-      tof_touch_raw_pub_->publish(tof_raw_msg);
+      if (tof_touch_raw == 65535) {  // out of range
+        RCLCPP_WARN(this->get_logger(), "TOF touch sensor out of range");
+        return;
+      } else if (tof_touch_raw > 1000) {  // ignore out of range
+        RCLCPP_WARN(this->get_logger(), "TOF touch sensor raw value out of range: %d", tof_touch_raw);
+        return;
+      } else {
+        std_msgs::msg::UInt16 tof_raw_msg;
+        tof_raw_msg.data = tof_touch_raw;
+        tof_touch_raw_pub_->publish(tof_raw_msg);
+      }
       int16_t tof_touch = 0;
       int16_t touch = frame.data[3];
+
+      if (tof_touch_raw <= tof_touch_threshold_low_) {
+        tof_touch_ = true;
+      } else {
+        if (tof_touch_raw >= tof_touch_threshold_high_) {
+          tof_touch_ = false;
+        }
+      }
+
       if (touch_mode_ == "dual") {
         if (touch == 0) {
-          if (tof_touch_raw <= tof_touch_threshold_) {
-            touch = 1;
-          } else {
-            touch = 0;
-          }
+          touch = tof_touch_;
         }
       } else if (touch_mode_ == "cap") {
         // noop
       } else if (touch_mode_ == "tof") {
-        if (tof_touch_raw <= tof_touch_threshold_) {
-          touch = 1;
-        } else {
-          touch = 0;
-        }
-      }
-      if (tof_touch_raw >= 16 && tof_touch_raw <= 25) {
-        tof_touch = 1;
-      } else {
-        tof_touch = 0;
+        touch = tof_touch_;
       }
       std_msgs::msg::Int16 tof_touch_msg;
-      tof_touch_msg.data = tof_touch;
+      tof_touch_msg.data = tof_touch_;
       tof_touch_pub_->publish(tof_touch_msg);
       std_msgs::msg::Int16 touch_msg;
       touch_msg.data = touch;
@@ -940,7 +950,9 @@ private:
   sensor_msgs::msg::Imu imu_msg;
   sensor_msgs::msg::Imu imu_raw_msg;
   std::string touch_mode_;
-  int tof_touch_threshold_;
+  int tof_touch_threshold_low_;
+  int tof_touch_threshold_high_;
+  bool tof_touch_;
   int can_socket_;
   rclcpp::Publisher<sensor_msgs::msg::Temperature>::SharedPtr temperature_1_pub_;
   rclcpp::Publisher<sensor_msgs::msg::Temperature>::SharedPtr temperature_2_pub_;

--- a/cabot_can/src/cabot_can_node.cpp
+++ b/cabot_can/src/cabot_can_node.cpp
@@ -719,11 +719,9 @@ private:
       diag_cap_touch_raw_->tick(this->now());
       uint16_t tof_touch_raw = (((uint16_t)frame.data[1]) << 8) | ((uint16_t)frame.data[0]);
       if (tof_touch_raw == 65535) {  // out of range
-        RCLCPP_WARN(this->get_logger(), "TOF touch sensor out of range");
-        return;
+        RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1000, "TOF touch sensor out of range");
       } else if (tof_touch_raw > 1000) {  // ignore out of range
-        RCLCPP_WARN(this->get_logger(), "TOF touch sensor raw value out of range: %d", tof_touch_raw);
-        return;
+        RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1000, "TOF touch sensor raw value out of range: %d", tof_touch_raw);
       } else {
         std_msgs::msg::UInt16 tof_raw_msg;
         tof_raw_msg.data = tof_touch_raw;

--- a/motor_controller/odriver_can_adapter/CMakeLists.txt
+++ b/motor_controller/odriver_can_adapter/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(rclcpp REQUIRED)
 find_package(diagnostic_updater REQUIRED)
 find_package(odriver_msgs REQUIRED)
 find_package(odrive_can REQUIRED)
+find_package(std_srvs REQUIRED)
 
 add_executable(odriver_can_adapter_node
   src/odriver_can_adapter_node.cpp
@@ -25,6 +26,7 @@ ament_target_dependencies(
   "diagnostic_updater"
   "odriver_msgs"
   "odrive_can"
+  "std_srvs"
 )
 
 include_directories(include)

--- a/motor_controller/odriver_can_adapter/include/odrive_manager.hpp
+++ b/motor_controller/odriver_can_adapter/include/odrive_manager.hpp
@@ -24,6 +24,11 @@
 
 #include <string>
 
+#include <odrive_can/msg/control_message.hpp>
+#include <odrive_can/msg/controller_status.hpp>
+#include <odrive_can/msg/o_drive_status.hpp>
+#include <odrive_can/srv/axis_state.hpp>
+
 class ODriveManager
 {
 public:
@@ -31,7 +36,8 @@ public:
   ~ODriveManager();
 
   void controllerStatusCallback(const odrive_can::msg::ControllerStatus::SharedPtr msg);
-  void callAxisStateService(unsigned int axis_state);
+  void odriveStatusCallback(const odrive_can::msg::ODriveStatus::SharedPtr msg);
+  bool callAxisStateService(unsigned int axis_state);
   void publishControlMessage(const odrive_can::msg::ControlMessage & msg);
   void publishControlMessage(int control_mode, int input_mode, double spd_m_per_sec);
   unsigned int getAxisState() {return axis_state_;}
@@ -44,6 +50,8 @@ public:
   double getSign() {return sign_;}
   bool isReady() {return ready_;}
   rclcpp::Time getLastStatusTime() {return last_status_time_;}
+  int getActiveErrors() {return active_errors_;}
+  int getDisarmReason() {return disarm_reason_;}
 
 private:
   rclcpp::Node * node_;
@@ -61,6 +69,8 @@ private:
   double last_dist_c_;
   double current_setpoint_;
   double current_measured_;
+  uint32_t active_errors_;
+  uint32_t disarm_reason_;
   bool ready_;
 
   rclcpp::Time status_time_;
@@ -73,4 +83,5 @@ private:
 
   rclcpp::Publisher<odrive_can::msg::ControlMessage>::SharedPtr control_message_pub_;
   rclcpp::Subscription<odrive_can::msg::ControllerStatus>::SharedPtr controller_status_sub_;
+  rclcpp::Subscription<odrive_can::msg::ODriveStatus>::SharedPtr odrive_status_sub_;
 };

--- a/motor_controller/odriver_can_adapter/launch/test.launch.py
+++ b/motor_controller/odriver_can_adapter/launch/test.launch.py
@@ -70,6 +70,9 @@ def generate_launch_description():
                 ('/motor_target', '/cabot/motor_target'),
                 ('/request_axis_state_left', '/cabot/request_axis_state_left'),
                 ('/request_axis_state_right', '/cabot/request_axis_state_right'),
+                ('/odrive_status_left', '/cabot/odrive_status_left'),
+                ('/odrive_status_right', '/cabot/odrive_status_right'),
+                ('/set_odrive_power', '/set_24v_power_odrive'),
             ],
         ),
         Node(

--- a/motor_controller/odriver_can_adapter/package.xml
+++ b/motor_controller/odriver_can_adapter/package.xml
@@ -29,6 +29,8 @@
   <depend>rclcpp</depend>
   <depend>odriver_msgs</depend>
   <depend>odrive_can</depend>
+  <depend>std_srvs</depend>
+  <depend>diagnostic_updater</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/motor_controller/odriver_can_adapter/src/odrive_manager.cpp
+++ b/motor_controller/odriver_can_adapter/src/odrive_manager.cpp
@@ -181,8 +181,8 @@ void ODriveManager::checkTimeoutServiceResponse(double timeout)
   using std::chrono::system_clock;
 
   double diff_time =
-    std::chrono::duration_cast<Milliseconds>(last_call_time_ - system_clock::now()).count();
-  if (!client_->wait_for_service(Seconds(0)) && diff_time >= timeout) {
+    std::chrono::duration_cast<Milliseconds>(system_clock::now() - last_call_time_).count();
+  if (diff_time >= timeout) {
     client_->prune_pending_requests();
     is_ready_axis_state_service_ = true;
   }

--- a/motor_controller/odriver_can_adapter/src/odrive_manager.cpp
+++ b/motor_controller/odriver_can_adapter/src/odrive_manager.cpp
@@ -24,10 +24,6 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <odrive_can/msg/control_message.hpp>
-#include <odrive_can/msg/controller_status.hpp>
-#include <odrive_can/srv/axis_state.hpp>
-
 #include "odrive_manager.hpp"
 
 using namespace std::chrono_literals;
@@ -41,6 +37,8 @@ ODriveManager::ODriveManager(
   dist_c_fixed_(0),
   last_dist_c_(std::numeric_limits<double>::quiet_NaN()),
   ready_(false),
+  active_errors_(0),
+  disarm_reason_(0),
   last_status_time_(node->get_clock()->now()),
   sign_(sign),
   wheel_diameter_m_(wheel_diameter_m)
@@ -60,6 +58,13 @@ ODriveManager::ODriveManager(
     controller_status_qos,
     std::bind(
       &ODriveManager::controllerStatusCallback,
+      this,
+      _1));
+  odrive_status_sub_ = node->create_subscription<odrive_can::msg::ODriveStatus>(
+    (std::string("/odrive_status_") + axis_name).c_str(),
+    controller_status_qos,
+    std::bind(
+      &ODriveManager::odriveStatusCallback,
       this,
       _1));
 
@@ -100,7 +105,13 @@ void ODriveManager::controllerStatusCallback(const odrive_can::msg::ControllerSt
   }
 }
 
-void ODriveManager::callAxisStateService(unsigned int axis_state)
+void ODriveManager::odriveStatusCallback(const odrive_can::msg::ODriveStatus::SharedPtr msg)
+{
+  active_errors_ = msg->active_errors;
+  disarm_reason_ = msg->disarm_reason;
+}
+
+bool ODriveManager::callAxisStateService(unsigned int axis_state)
 {
   using AxisState = odrive_can::srv::AxisState;
   using AxisStateClient = rclcpp::Client<AxisState>;
@@ -110,19 +121,22 @@ void ODriveManager::callAxisStateService(unsigned int axis_state)
   request->axis_requested_state = axis_state;
 
   if (is_ready_axis_state_service_) {
-    RCLCPP_INFO(
+    RCLCPP_INFO_THROTTLE(
       node_->get_logger(),
+      *node_->get_clock(),
+      2000,
       "call axis_state_%s service from %d mode to %d mode",
       axis_name_.c_str(),
       axis_state_,
       axis_state);
-    while (!client_->wait_for_service(std::chrono::seconds(1)) &&
-      rclcpp::ok())
-    {
-      RCLCPP_INFO(
+    if (rclcpp::ok() && !client_->wait_for_service(std::chrono::milliseconds(100))) {
+      RCLCPP_INFO_THROTTLE(
         node_->get_logger(),
+        *node_->get_clock(),
+        2000,
         "request_axis_state_%s service not available, waiting again...",
         axis_name_.c_str());
+      return false;
     }
 
     is_ready_axis_state_service_ = false;
@@ -134,7 +148,9 @@ void ODriveManager::callAxisStateService(unsigned int axis_state)
         (void) future;
         is_ready_axis_state_service_ = true;
       });
+    return true;
   }
+  return false;
 }
 
 void ODriveManager::publishControlMessage(const odrive_can::msg::ControlMessage & msg)

--- a/motor_controller/odriver_can_adapter/src/odriver_can_adapter_node.cpp
+++ b/motor_controller/odriver_can_adapter/src/odriver_can_adapter_node.cpp
@@ -185,7 +185,12 @@ private:
 
     odriver_msgs::msg::MotorStatus status;
 
-    status.header.stamp = this->get_clock()->now();
+    rclcpp::Time temp = odrive_left_->getLastStatusTime();
+    if (temp < odrive_right_->getLastStatusTime()) {
+      temp = odrive_right_->getLastStatusTime();
+    }
+    last_motor_status_time_ = temp;
+    status.header.stamp = temp;
 
     status.dist_left_c = sign_left * dist_left_c;
     status.dist_right_c = sign_right * dist_right_c;
@@ -204,13 +209,7 @@ private:
 
     status.current_measured_left = sign_left * current_measured_left;
     status.current_measured_right = sign_right * current_measured_right;
-
     motor_status_pub_->publish(status);
-    rclcpp::Time temp = odrive_left_->getLastStatusTime();
-    if (odrive_right_->getLastStatusTime() < temp) {
-      temp = odrive_right_->getLastStatusTime();
-    }
-    last_motor_status_time_ = temp;
 
     if (this->get_clock()->now() - last_motor_armed_time_ > power_reset_timeout_) {
       using SetBoolClient = rclcpp::Client<std_srvs::srv::SetBool>;


### PR DESCRIPTION
This pull request introduces several improvements and refactors across the Cabot and ODrive CAN adapter codebases, focusing on enhanced touch sensor handling, expanded diagnostics and control for ODrive motors, and configuration flexibility. The most significant changes are grouped below.

### Touch Sensor Handling Improvements

* Replaced the single ToF touch threshold parameter with two parameters (`tof_touch_threshold_low` and `tof_touch_threshold_high`) for improved hysteresis and reliability in touch detection. Updated related launch files, documentation, and the node implementation to support these changes. [[1]](diffhunk://#diff-88f9db628a0e5444f762c661d62426b9da4a63b49dc3ad00149997bf03f98dd4L22-R25) [[2]](diffhunk://#diff-92a7abf6e5ef3c6f0e18e16f2b90d0840bcdb8ed6f8ae15bdb83cfdbaafe6bceR43-R44) [[3]](diffhunk://#diff-92a7abf6e5ef3c6f0e18e16f2b90d0840bcdb8ed6f8ae15bdb83cfdbaafe6bceR79-R88) [[4]](diffhunk://#diff-92a7abf6e5ef3c6f0e18e16f2b90d0840bcdb8ed6f8ae15bdb83cfdbaafe6bceL89-R103) [[5]](diffhunk://#diff-2048cc10927877c6eaec4080761b844d416cb34d33b93a9a6a536de92908b384L133-R141) [[6]](diffhunk://#diff-2048cc10927877c6eaec4080761b844d416cb34d33b93a9a6a536de92908b384L292-R299) [[7]](diffhunk://#diff-2048cc10927877c6eaec4080761b844d416cb34d33b93a9a6a536de92908b384L709-R751) [[8]](diffhunk://#diff-2048cc10927877c6eaec4080761b844d416cb34d33b93a9a6a536de92908b384L943-R953)
* Updated the `cabot_base/config/cabot3-common.yaml` configuration to decrease the minimum laser scan range, potentially improving obstacle detection at close distances.

### ODrive CAN Adapter Enhancements

* Added subscriptions to new ODrive status topics (`/odrive_status_left`, `/odrive_status_right`) and exposed additional diagnostics (`active_errors`, `disarm_reason`) via the `ODriveManager` class. Refactored the axis state service to return success/failure and improved service availability handling. [[1]](diffhunk://#diff-c9ade6ae5fd7bfc3b8d90fc05fab00c8f707815c8ad4654649eff1c9d1502ec6R27-R40) [[2]](diffhunk://#diff-c9ade6ae5fd7bfc3b8d90fc05fab00c8f707815c8ad4654649eff1c9d1502ec6R53-R54) [[3]](diffhunk://#diff-c9ade6ae5fd7bfc3b8d90fc05fab00c8f707815c8ad4654649eff1c9d1502ec6R72-R73) [[4]](diffhunk://#diff-c9ade6ae5fd7bfc3b8d90fc05fab00c8f707815c8ad4654649eff1c9d1502ec6R86) [[5]](diffhunk://#diff-b03c73ecfa1d7b784240e2f4537714a6abd40ad4052422ee8a45d7381c2b305dL27-L30) [[6]](diffhunk://#diff-b03c73ecfa1d7b784240e2f4537714a6abd40ad4052422ee8a45d7381c2b305dR40-R41) [[7]](diffhunk://#diff-b03c73ecfa1d7b784240e2f4537714a6abd40ad4052422ee8a45d7381c2b305dR63-R69) [[8]](diffhunk://#diff-b03c73ecfa1d7b784240e2f4537714a6abd40ad4052422ee8a45d7381c2b305dL103-R114) [[9]](diffhunk://#diff-b03c73ecfa1d7b784240e2f4537714a6abd40ad4052422ee8a45d7381c2b305dL113-R139) [[10]](diffhunk://#diff-b03c73ecfa1d7b784240e2f4537714a6abd40ad4052422ee8a45d7381c2b305dR151-R153) [[11]](diffhunk://#diff-b03c73ecfa1d7b784240e2f4537714a6abd40ad4052422ee8a45d7381c2b305dL168-R185)
* Updated launch files to remap new ODrive status topics and the power control service for improved integration and testing. [[1]](diffhunk://#diff-ed7c960e9d7f0cee7b05a6b3e0ad7997163bcbfa9ac6e96ba238c1a51378a24bR548-R550) [[2]](diffhunk://#diff-85d26f239ae2bbb856f2d224a9bf809186d0f7363e941b425705d0e747ac9611R73-R75)

### Motor Control and Safety

* Reduced the maximum acceleration parameter for the Cabot robot, which may improve safety and smoothness of motion.

### Build and Dependency Updates

* Added `std_srvs` and `diagnostic_updater` as dependencies in the ODrive CAN adapter package and build files to support new features and diagnostics. [[1]](diffhunk://#diff-56172c337f0d47e8f62ad5d53060e9bc97569c058526e9daf7be13087853f4a6R14) [[2]](diffhunk://#diff-56172c337f0d47e8f62ad5d53060e9bc97569c058526e9daf7be13087853f4a6R29) [[3]](diffhunk://#diff-c1d68b21a6ff3616fdc0bc899fc3a6412084db57474edb97fa01398fcaf6b70aR32-R33)

### Documentation

* Updated the Cabot CAN README to clarify touch sensor parameters and document the new threshold logic.