### PR TITLE
Wait for DDS interface IPv4 before launching cabot_base

### DIFF
--- a/script/launch_driver.sh
+++ b/script/launch_driver.sh
@@ -41,6 +41,32 @@ source $scriptdir/cabot_util.sh
 
 trap signal INT TERM
 
+function wait_for_dds_interface_ipv4() {
+    local interface_name="$1"
+    local timeout_sec="${2:-30}"
+    local start
+    start=$(date +%s)
+
+    if [[ -z "$interface_name" ]]; then
+        return 0
+    fi
+
+    blue "waiting for global IPv4 on $interface_name (timeout=${timeout_sec}s)"
+
+    while true; do
+        if ip -4 -o addr show dev "$interface_name" scope global | grep -q 'inet '; then
+            blue "$interface_name has a global IPv4 address"
+            return 0
+        fi
+
+        if [[ $(( $(date +%s) - start )) -ge "$timeout_sec" ]]; then
+            err "$interface_name did not get IPv4 within ${timeout_sec}s"
+            return 1
+        fi
+        snore 1
+    done
+}
+
 function signal() {
     blue "trap launch_driver.sh "
 
@@ -102,6 +128,10 @@ venv_path=/opt/venv/$cabot_major/bin/activate
 cabot_launch_py=$cabot_major.launch.py
 
 source $venv_path
+
+if [[ -n "$CYCLONEDDS_NETWORK_INTERFACE_NAME" ]]; then
+    wait_for_dds_interface_ipv4 "$CYCLONEDDS_NETWORK_INTERFACE_NAME" "${CYCLONEDDS_NETWORK_INTERFACE_WAIT_TIMEOUT_SEC:-30}" || exit 1
+fi
 
 blue "bringup $CABOT_MODEL base"
 com="$command_prefix ros2 launch -n cabot_base $cabot_launch_py $command_postfix"


### PR DESCRIPTION
- https://github.com/miraikan-research/TODO/issues/1417 の対応
  - ethLAN5のネットワーク設定がされる前にcabot_can_nodeを起動しようとして失敗しているように見えるのでネットワーク設定がされるのを待つ仕組みを導入